### PR TITLE
restructure the meta stuff, declare v2.0.0

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,33 @@
+{
+  "eqeqeq": true,
+  "forin": true,
+  "globalstrict": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": "nofunc",
+  "newcap": true,
+  "noarg": true,
+  "node": true,
+  "quotmark": "single",
+  "strict": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true,
+  "globals": {
+    "$": false,
+    "Ember": false,
+    "after": false,
+    "afterEach": false,
+    "before": false,
+    "beforeEach": false,
+    "context": false,
+    "describe": false,
+    "exports": false,
+    "global": false,
+    "it": false,
+    "jQuery": false,
+    "localStorage": false,
+    "module": false,
+    "require": false
+  }
+}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Jonathan Clem
+Copyright (c) 2014 Heroku
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ RestModel is a library for interacting with a REST API in Ember. Its goal is to
 provide a library with predictable behavior and which can be easily extended to
 meet custom needs.
 
+
+**DISCLAIMER: Consider [ember-data](https://github.com/emberjs/data) instead.**
+
+
 ## Documentation
 
 This readme, and more detailed work-in-progress

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,15 @@
 {
   "name": "rest-model",
   "main": "dist/rest-model.js",
-  "version": "1.8.4",
+  "version": "2.0.0",
   "authors": [
-    "Jonathan Clem <jonathan@jclem.net>"
+    "Jonathan Clem <jonathan@jclem.net>",
+    "Josh Lewis <josh.w.lewis@gmail.com>",
+    "Jack Anderson <hi@janderson.me>",
+    "Raul Barroso <ra.barroso@gmail.com>",
+    "Andy Appleton <andysapple@gmail.com>",
+    "Nando Vieira <fnando.vieira@gmail.com>",
+    "HIT <hit@heroku.com>"
   ],
   "description": "simple library for using REST APIs in ember",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,4 +1,25 @@
 {
+  "name": "rest-model",
+  "description": "[![Build Status](https://travis-ci.org/heroku/rest-model.svg?branch=master)](https://travis-ci.org/jclem/rest-model)",
+  "version": "2.0.0",
+  "repository": { "type": "git", "url": "git+https://github.com/heroku/rest-model.git" },
+  "keywords": ["rest", "model", "rest-model", "ember", "ajax", "persistence"],
+  "author": "HIT <hit@heroku.com>",
+  "contributors": [
+    "Jonathan Clem <jonathan@jclem.net>",
+    "Josh Lewis <josh.w.lewis@gmail.com>",
+    "Jack Anderson <hi@janderson.me>",
+    "Raul Barroso <ra.barroso@gmail.com>",
+    "Andy Appleton <andysapple@gmail.com>",
+    "Nando Vieira <fnando.vieira@gmail.com>"
+  ],
+  "license": "MIT",
+  "bugs": { "url": "https://github.com/heroku/rest-model/issues" },
+  "homepage": "https://github.com/heroku/rest-model#readme",
+  "scripts": {
+    "build": "gulp",
+    "test": "mocha test/**/*-test.js -t 50"
+  },
   "devDependencies": {
     "benv": "^0.1.5",
     "bower": "^1.3.2",
@@ -10,42 +31,5 @@
     "should": "^3.3.1",
     "sinon": "^1.9.1",
     "gulp-watch": "^0.6.9"
-  },
-  "scripts": {
-    "build": "gulp",
-    "test": "mocha test/**/*-test.js -t 50"
-  },
-  "jshintConfig": {
-    "eqeqeq": true,
-    "forin": true,
-    "globalstrict": true,
-    "immed": true,
-    "indent": 2,
-    "latedef": "nofunc",
-    "newcap": true,
-    "noarg": true,
-    "node": true,
-    "quotmark": "single",
-    "strict": true,
-    "trailing": true,
-    "undef": true,
-    "unused": true,
-    "globals": {
-      "$": false,
-      "Ember": false,
-      "after": false,
-      "afterEach": false,
-      "before": false,
-      "beforeEach": false,
-      "context": false,
-      "describe": false,
-      "exports": false,
-      "global": false,
-      "it": false,
-      "jQuery": false,
-      "localStorage": false,
-      "module": false,
-      "require": false
-    }
   }
 }


### PR DESCRIPTION
- [x] move jshint config to `.jshintrc`
- [x] update licenses, authors, etc to `hit@heroku.com` [which is accurate since jclem wrote this for/as HIT?]
- [x] flesh out missing fields in `package.json` such as the version number
