### PR TITLE
utils.arraysEqual should probably compare array elements....

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ exports.arraysEqual = function(array1, array2) {
 
   var value1, value2;
 
-  for (var i; i < array1.length; i++) {
+  for (var i=0; i < array1.length; i++) {
     value1 = array1[i];
     value2 = array2[i];
 

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+require('./test-helper');
+
+var Utils = require('../lib/utils');
+
+describe('RestModel.utils', function() {
+  describe('arraysEqual', function() {
+    describe('with arrays of strings', function() {
+      it('should return false', function() {
+        var arr1 = ['one', 'two'];
+        var arr2 = ['two', 'three'];
+        var result = Utils.arraysEqual(arr1, arr2);
+        result.should.eql(false);
+      });
+      it('should return true', function() {
+        var arr = ['one', 'two'];
+        var result = Utils.arraysEqual(arr, arr);
+        result.should.eql(true);
+      });
+    });
+    describe('with arrays of objects', function() {
+      it('should return false', function() {
+        var arr1 = [{name: 'one'}, {name: 'two'}];
+        var arr2 = [{name: 'two'}, {name: 'three'}];
+        var result = Utils.arraysEqual(arr1, arr2);
+        result.should.eql(false);
+      });
+      it('should return true', function() {
+        var arr = [{name: 'one'}, {name: 'two'}];
+        var result = Utils.arraysEqual(arr, arr);
+        result.should.eql(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Before:**

``` javascript
utils.arraysEqual(['a'],['b'])
// true
```

**After:**

``` javascript
utils.arraysEqual(['a'],['b'])
// false
```

Pretty much all this was doing was comparing length, even though it looks like it was designed to check element equality. This is being consumed by ModelV2, so it represents a rather important bug.
